### PR TITLE
Detect multipart form and parse accordingly in ConcreteContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+*.test
+*.prof
+
+.idea/

--- a/context.go
+++ b/context.go
@@ -229,7 +229,8 @@ func (c *ConcreteContext) parseRequest() error {
 		return nil
 	}
 	var err error
-	if c.request.Header["Content-Type"][0][0:9] == "multipart" {
+	if len(c.request.Header["Content-Type"]) > 0 &&
+		c.request.Header["Content-Type"][0][0:9] == "multipart" {
 		// ParseMultipartForm results in a blank error if not multipart
 		err = c.request.ParseMultipartForm(1024*20)
 	} else {

--- a/context.go
+++ b/context.go
@@ -224,19 +224,16 @@ func (c *ConcreteContext) RenderContext() map[string]interface{} {
 
 // parseRequest parses our params from the request form (if any)
 func (c *ConcreteContext) parseRequest() error {
-
 	// If we have no request body, return
 	if c.request.Body == nil {
 		return nil
 	}
-
-	// If we have a request body, parse it
-	// ParseMultipartForm results in a blank error if not multipart
-	err := c.request.ParseForm()
-	//   err := c.request.ParseMultipartForm(1024*20)
-	if err != nil {
-		return err
+	var err error
+	if c.request.Header["Content-Type"][0][0:9] == "multipart" {
+		// ParseMultipartForm results in a blank error if not multipart
+		err = c.request.ParseMultipartForm(1024*20)
+	} else {
+		err = c.request.ParseForm()
 	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
In fragmenta-cms users are created via a multipart form so params were returning blank and so could not create the user. Update is probably similar.
